### PR TITLE
Bug fix: Shouldn’t replace the crystal array with an array of deleted…

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,19 +35,19 @@
 
         var crystalOnePlace = randomCompInt(0, 3);
         var crystal1Val = crystalValues[crystalOnePlace];
-        crystalValues = crystalValues.splice(crystalOnePlace, 1);
+        crystalValues.splice(crystalOnePlace, 1);
         
         console.log("What's left in my array: " + crystalValues);
 
         var crystalTwoPlace = randomCompInt(0, 2);
         var crystal2Val = crystalValues[crystalTwoPlace];
-        crystalValues = crystalValues.splice(crystalTwoPlace, 1);
+        crystalValues.splice(crystalTwoPlace, 1);
 
         console.log("What's left in my array: " + crystalValues);
 
         var crystalThreePlace = randomCompInt(0, 1);
         var crystal3Val = crystalValues[crystalThreePlace];
-        crystalValues = crystalValues.splice(crystalThreePlace, 1);
+        crystalValues.splice(crystalThreePlace, 1);
         
         console.log("What's left in my array: " + crystalValues);
 


### PR DESCRIPTION
… values

I feel like a dummy. I should have read the documentation in detail.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice

splice returns an array of the deleted items. It DOES modify, in place, the contents of the array.